### PR TITLE
updated theme assignments

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Extensions/W3WTheme+.swift
+++ b/Sources/W3WSwiftComponentsOcr/Extensions/W3WTheme+.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dave Duprey on 13/01/2024.
+//
+
+import Foundation
+import W3WSwiftThemes
+
+public extension W3WTheme {
+  
+  /// function to make a theme suitable to use in the OCR Component
+  /// - Parameters:
+  ///   - text: colour for the text
+  ///   - lightText: lighter colour for secondary text
+  ///   - background: background colout
+  ///   - lineDefault: viewfinder corner line colour
+  ///   - lineSuccess: viewfinder corner line colour for when an address is found
+  ///   - error:  viewfinder corner line colour for when there is an error
+  static func forOcr(
+    text:           W3WColor?  = .text,
+    lightText:      W3WColor?  = .secondaryGray,
+    background:     W3WColor?  = .background,
+    lineDefault:    W3WColor?  = .white,
+    lineSuccess:    W3WColor?  = .green,
+    error:          W3WColor?  = .errorRed,
+    lineThickness:  W3WLineThickness = .fourPoint,
+    fonts:          W3WFonts   = W3WFonts(),
+    padding:        W3WPadding = .none,
+    rowHeight:      W3WRowHeight = .medium
+    
+  ) -> W3WTheme {
+
+    let cornerRadius = W3WCornerRadius(value: lineThickness.value * 0.5)
+    
+    let ocrColours = W3WColors(foreground: text, background: background, success: W3WBasicColors(foreground: lineSuccess), error: W3WBasicColors(foreground: error), line: lineDefault)
+    let ocrStyles  = W3WStyles(cornerRadius: cornerRadius, fonts: fonts, padding: padding, rowHeight: rowHeight, lineThickness: lineThickness)
+    let ocrScheme  = W3WScheme(colors: ocrColours, styles: ocrStyles)
+    
+    return W3WTheme(base: .standard, cells: .standardCells, ocr: ocrScheme)
+  }
+  
+}

--- a/Sources/W3WSwiftComponentsOcr/W3WOcrViewController+theme.swift
+++ b/Sources/W3WSwiftComponentsOcr/W3WOcrViewController+theme.swift
@@ -20,57 +20,99 @@ extension W3WOcrViewController {
       }
       let scheme: W3WScheme
       switch state {
+      
       case .idle:
-        scheme = W3WScheme(colors: W3WColors(foreground: W3WColor(uiColor: W3WSettings.ocrPrimaryTextColor),
-                                             background: .white,
-                                             line: .white),
-                           styles: W3WStyles(cornerRadius: W3WCornerRadius(floatLiteral: 3.0),
-                                             fonts: W3WFonts(font: .systemFont(ofSize: 17.0, weight: .semibold)),
-                                             textAlignment: W3WTextAlignment(value: .center),
-                                             padding: W3WPadding(insets: .zero),
-                                             rowHeight: W3WRowHeight(floatLiteral: 24.0),
-                                             lineThickness: W3WLineThickness(floatLiteral: 6.0)))
+        scheme = W3WScheme(
+        
+          colors: W3WColors(
+            foreground: theme?[.ocr]?.colors?.foreground,
+            background: theme?[.ocr]?.colors?.background,
+            line:       theme?[.ocr]?.colors?.line
+          ),
+         
+          styles: W3WStyles(
+            cornerRadius: theme?[.ocr]?.styles?.cornerRadius,
+            fonts: theme?[.ocr]?.styles?.fonts,
+            textAlignment: W3WTextAlignment(value: .center),
+            padding: theme?[.ocr]?.styles?.padding,
+            rowHeight: W3WRowHeight(floatLiteral: Float((theme?[.ocr]?.styles?.rowHeight?.value ?? 0.0) / 2.0)),
+            lineThickness: theme?[.ocr]?.styles?.lineThickness
+          )
+        )
+        
       case .detecting:
-        scheme = W3WScheme(colors: W3WColors(foreground: W3WColor(uiColor: W3WSettings.ocrPrimaryTextColor), 
-                                             background: .white,
-                                             line: .white),
-                           styles: W3WStyles(cornerRadius: W3WCornerRadius(floatLiteral: 6.0),
-                                             fonts: W3WFonts(font: .systemFont(ofSize: 17.0, weight: .semibold)),
-                                             textAlignment: W3WTextAlignment(value: .center),
-                                             padding: W3WPadding(insets: .zero),
-                                             rowHeight: W3WRowHeight(floatLiteral: 48.0),
-                                             lineThickness: W3WLineThickness(floatLiteral: 12.0)))
+        scheme = W3WScheme(
+          colors: W3WColors(
+            foreground: theme?[.ocr]?.colors?.foreground,
+            background: theme?[.ocr]?.colors?.background,
+            line:       theme?[.ocr]?.colors?.line
+          ),
+          
+          styles: W3WStyles(
+            cornerRadius: W3WCornerRadius(value: (theme?[.ocr]?.styles?.cornerRadius?.value ?? 0.0) * 2.0),
+            fonts: theme?[.ocr]?.styles?.fonts,
+            textAlignment: W3WTextAlignment(value: .center),
+            padding: theme?[.ocr]?.styles?.padding,
+            rowHeight: theme?[.ocr]?.styles?.rowHeight,
+            lineThickness: W3WLineThickness(value: (theme?[.ocr]?.styles?.lineThickness?.value ?? 0.0) * 2.0)
+          )
+        )
+        
       case .scanning:
-        scheme = W3WScheme(colors: W3WColors(foreground: W3WColor(uiColor: W3WSettings.ocrPrimaryTextColor), 
-                                             background: .white,
-                                             line: W3WColor(uiColor: W3WSettings.ocrTargetSuccess)),
-                           styles: W3WStyles(cornerRadius: W3WCornerRadius(floatLiteral: 6.0),
-                                             fonts: W3WFonts(font: .systemFont(ofSize: 17.0, weight: .semibold)),
-                                             textAlignment: W3WTextAlignment(value: .center),
-                                             padding: W3WPadding(insets: .zero),
-                                             rowHeight: W3WRowHeight(floatLiteral: 48.0),
-                                             lineThickness: W3WLineThickness(floatLiteral: 12.0)))
+        scheme = W3WScheme(
+          colors: W3WColors(
+            foreground: theme?[.ocr]?.colors?.foreground,
+            background: theme?[.ocr]?.colors?.background,
+            line:       theme?[.ocr]?.colors?.success?.foreground
+          ),
+          
+          styles: W3WStyles(
+            cornerRadius: W3WCornerRadius(value: (theme?[.ocr]?.styles?.cornerRadius?.value ?? 0.0) * 2.0),
+            fonts: theme?[.ocr]?.styles?.fonts,
+            textAlignment: W3WTextAlignment(value: .center),
+            padding: theme?[.ocr]?.styles?.padding,
+            rowHeight: theme?[.ocr]?.styles?.rowHeight,
+            lineThickness: W3WLineThickness(value: (theme?[.ocr]?.styles?.lineThickness?.value ?? 0.0) * 2.0)
+          )
+        )
+        
       case .scanned:
-        scheme = W3WScheme(colors: W3WColors(foreground: W3WColor(uiColor: W3WSettings.ocrPrimaryGreyTextColor), 
-                                             background: .white,
-                                             line: .white),
-                           styles: W3WStyles(cornerRadius: W3WCornerRadius(floatLiteral: 3.0),
-                                             fonts: W3WFonts(font: .systemFont(ofSize: 14.0, weight: .regular)),
-                                             textAlignment: W3WTextAlignment(value: .left),
-                                             padding: W3WPadding(insets: .zero),
-                                             rowHeight: W3WRowHeight(floatLiteral: 24.0),
-                                             lineThickness: W3WLineThickness(floatLiteral: 6.0)))
+        scheme = W3WScheme(
+          colors: W3WColors(
+            foreground: theme?[.ocr]?.colors?.secondary,
+            background: theme?[.ocr]?.colors?.background,
+            line:       theme?[.ocr]?.colors?.line
+          ),
+          
+          styles: W3WStyles(
+            cornerRadius: theme?[.ocr]?.styles?.cornerRadius,
+            fonts: theme?[.ocr]?.styles?.fonts,
+            textAlignment: W3WTextAlignment(value: .left),
+            padding: theme?[.ocr]?.styles?.padding,
+            rowHeight: W3WRowHeight(floatLiteral: Float((theme?[.ocr]?.styles?.rowHeight?.value ?? 0.0) / 2.0)),
+            lineThickness: theme?[.ocr]?.styles?.lineThickness
+          )
+        )
+        
       case .error:
-        scheme = W3WScheme(colors: W3WColors(foreground: W3WColor(uiColor: W3WSettings.ocrPrimaryTextColor),
-                                             background: .white,
-                                             line: W3WColor(uiColor: W3WSettings.ocrTargetFailed)),
-                           styles: W3WStyles(cornerRadius: W3WCornerRadius(floatLiteral: 6.0),
-                                             fonts: W3WFonts(font: .systemFont(ofSize: 17.0, weight: .semibold)),
-                                             textAlignment: W3WTextAlignment(value: .center),
-                                             padding: W3WPadding(insets: .zero),
-                                             rowHeight: W3WRowHeight(floatLiteral: 48.0),
-                                             lineThickness: W3WLineThickness(floatLiteral: 12.0)))
+        scheme = W3WScheme(
+          colors: W3WColors(
+            foreground: theme?[.ocr]?.colors?.foreground,
+            background: theme?[.ocr]?.colors?.background,
+            line:       theme?[.ocr]?.colors?.error?.foreground
+          ),
+          
+          styles: W3WStyles(
+            cornerRadius: W3WCornerRadius(value: (theme?[.ocr]?.styles?.cornerRadius?.value ?? 0.0) * 2.0),
+            fonts: theme?[.ocr]?.styles?.fonts,
+            textAlignment: W3WTextAlignment(value: .center),
+            padding: W3WPadding(insets: .zero),
+            rowHeight: theme?[.ocr]?.styles?.rowHeight,
+            lineThickness: W3WLineThickness(value: (theme?[.ocr]?.styles?.lineThickness?.value ?? 0.0) * 2.0)
+          )
+        )
       }
+      
       theme?[state.setType] = scheme
     }
   }

--- a/Sources/W3WSwiftComponentsOcr/W3WOcrViewController.swift
+++ b/Sources/W3WSwiftComponentsOcr/W3WOcrViewController.swift
@@ -129,7 +129,7 @@ open class W3WOcrViewController: W3WViewController {
   }()
   
   // MARK: - Init
-  public convenience init(ocr: W3WOcrProtocol, theme: W3WTheme? = nil) {
+  public convenience init(ocr: W3WOcrProtocol, theme: W3WTheme? = W3WTheme.forOcr()) {
     self.init(theme: theme)
     set(ocr: ocr)
   }


### PR DESCRIPTION
I've opted to merge this to the MT-6366 branch as it seems easiest.

I've modified `setupOcrScheme()` to use a standard theme and distribute values.
Also a convenience static function `W3WTheme.forOcr() -> W3WTheme` for easily making themes for OCR