### PR TITLE
[MT-6654] Fix crash when starting camera

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Camera/W3WOcrCamera.swift
+++ b/Sources/W3WSwiftComponentsOcr/Camera/W3WOcrCamera.swift
@@ -111,8 +111,8 @@ public class W3WOcrCamera: W3WVideoStream {
     sessionQueue.async { [weak self] in
       print(#function, "async ", "STOP")
       self?.session?.stopRunning()
+      self?.disconnectInputAndOutput()
     }
-    disconnectInputAndOutput()
 #endif
   }
   
@@ -230,7 +230,6 @@ public class W3WOcrCamera: W3WVideoStream {
   func disconnectInputAndOutput() {
     sessionQueue.async { [weak self] in
       //print(#function, "START")
-      self?.session?.beginConfiguration()
       for input in self?.session?.inputs ?? [] {
         self?.session?.removeInput(input)
       }
@@ -238,7 +237,6 @@ public class W3WOcrCamera: W3WVideoStream {
       for output in self?.session?.outputs ?? [] {
         self?.session?.removeOutput(output)
       }
-      self?.session?.commitConfiguration()
       //print(#function, "STOP")
     }
   }


### PR DESCRIPTION
Because I can not reproduce the crash, I just guess that it's related to the below one
https://console.firebase.google.com/u/1/project/what3words-b1cb8/crashlytics/app/ios:com.what3words.ios.what3words/issues/295645b6696b80aa9577d4484da3946f?time=last-seven-days&types=crash&versions=4.32.1%20(2)&sessionEventKey=a3af2374fd2345fd8ea38e13eea4f248_1923069294032573715

Based on this [documentation](https://developer.apple.com/documentation/avfoundation/avcapturesession), we have to perform the session's actions on a serial queue. Currently we're using the global concurrent queue that may cause the issue.