### PR TITLE
[MT-7848] fix bottom sheet ui when content is too narrow

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/w3w-swift-design-swiftui/W3WSuBottomSheet.swift
+++ b/Sources/W3WSwiftComponentsOcr/w3w-swift-design-swiftui/W3WSuBottomSheet.swift
@@ -41,6 +41,7 @@ public struct W3WSuBottomSheet<Accessory: View, Content: View>: View {
             .padding(W3WPadding.medium.value)
           
           content()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(background)
         .cornerRadius(cornerRadius, corners: [.topLeft, .topRight])


### PR DESCRIPTION
<img width="271" height="563" alt="Screenshot 2025-07-13 at 15 55 37" src="https://github.com/user-attachments/assets/ab8f37a2-6d32-478c-a53f-a7164b1a0a75" />
