### PR TITLE
changed native ocr to return [] on no results

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Lib/Ocr/W3WOcrNative.swift
+++ b/Sources/W3WSwiftComponentsOcr/Lib/Ocr/W3WOcrNative.swift
@@ -277,9 +277,10 @@ public class W3WOcrNative: W3WOcrProtocol {
         }
       }
       
-      if suggestions.count > 0 {
-        completion(suggestions, nil)
-      }
+      // condition removed to allow empty results through for "no results" feedback
+      //if suggestions.count > 0 {
+      completion(suggestions, nil)
+      //}
 
       // only return boxes if there is only one
       if frameInfo.boxes.count > 1 {


### PR DESCRIPTION
OCR native now returns an empty array when no results are found.  Previously it didn't do anything.