### PR TITLE
rework bottom sheet logic

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicBase.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicBase.swift
@@ -25,13 +25,13 @@ class W3WBottomSheetLogicBase: W3WBottomSheetLogicProtocol, W3WEventSubscriberPr
   var suggestions: W3WSelectableSuggestions
   
   /// the not found message
-  lazy var notFound =  W3WPanelItem.heading(W3WLive<W3WString>(translations.get(id: "ocr_import_photo_errorMessage").w3w))
+  lazy var notFound =  W3WPanelItem.heading(translations.get(id: "ocr_import_photo_errorMessage"))
 
   /// the invitation to scan message
-  lazy var scanMessage =  W3WPanelItem.heading(W3WLive<W3WString>(translations.get(id: "ocr_scan_3wa").w3w))
+  lazy var scanMessage =  W3WPanelItem.heading(translations.get(id: "ocr_scan_3wa"))
 
   /// the invitation to scan message
-  lazy var blankMessage =  W3WPanelItem.heading(W3WLive<W3WString>("".w3w))
+  lazy var blankMessage =  W3WPanelItem.heading("")
 
   /// the try again button
   var tryAgainItem: W3WPanelItem = .button(.init(onTap: {}))
@@ -116,7 +116,7 @@ class W3WBottomSheetLogicBase: W3WBottomSheetLogicProtocol, W3WEventSubscriberPr
     tryAgainItem = W3WPanelItem.button(tryAgainButton)
     
     // initial set up of the panel
-    panelViewModel.input.send(.add(item: .suggestions(suggestions)))
+    panelViewModel.input.send(.add(item: .suggestions(suggestions.allSuggestions)))
 
     // set up the footer
     updateFooterStatus()

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicInsanity.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicInsanity.swift
@@ -62,44 +62,4 @@ class W3WBottomSheetLogicInsanity: W3WBottomSheetLogicBase {
     onSelectAllButton()
   }
 
- 
-  // Logic
-  
-  
-  /// logic to update the footer text and buttons
-  override func updateFooterStatus() {
-    let footer: W3WPanelItem = .buttonsAndTitle(convert(footerButtons: footerButtons), text: footerText, highlightedText: selectedSuggestionsCount)
-    
-    // if there are selected suggestions then show the footer
-    if suggestions.selectedCount() > 0 {
-      panelViewModel.input.send(.footer(item: footer))
-    } else {
-      panelViewModel.input.send(.footer(item: nil))
-      panelViewModel.input.send(.remove(item: tryAgainItem))
-      panelViewModel.input.send(.remove(item: notFound))
-      if let resultsFound, !resultsFound {
-        panelViewModel.input.send(.add(item: tryAgainItem))
-        panelViewModel.input.send(.add(item: notFound))
-      }
-    }
-    
-    /// show/hide selection buttons if there any selectable suggestions, i.e pro mode
-    if selectableSuggestionList.value {
-      if suggestions.count() > 0  {
-        showSelectionButtons()
-      } else {
-        hideSelectionButtons()
-      }
-      /// otherwise show/hide `Scanned` title
-    } else {
-      if suggestions.count() > 0  {
-        showScannedTitle()
-      } else {
-        hideScannedTitle()
-      }
-    }
-    
-    updateFooterText()
-  }
-
 }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicSensible.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Common/W3WBottomSheetLogicSensible.swift
@@ -51,7 +51,7 @@ class W3WBottomSheetLogicSensible: W3WBottomSheetLogicBase {
   
   /// logic to update the footer text and buttons
   override func updateFooterStatus() {
-    let footer: W3WPanelItem = .buttonsAndTitle(convert(footerButtons: footerButtons), text: footerText, highlightedText: selectedSuggestionsCount)
+    let footer: W3WPanelItem = .buttonsAndTitle(convert(footerButtons: footerButtons), text: footerText.value.asString(), highlightedText: selectedSuggestionsCount.value.asString())
     
     // if there are selected suggestions then show the footer
     if suggestions.selectedCount() > 0 {

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Events/W3WOcrOutputEvent.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Events/W3WOcrOutputEvent.swift
@@ -11,7 +11,7 @@ import W3WSwiftAppEvents
 
 
 /// output events for ocr
-public enum W3WOcrOutputEvent: W3WAppEventConvertable {
+public enum W3WOcrOutputEvent {
   
   /// error
   case error(W3WError)
@@ -31,47 +31,58 @@ public enum W3WOcrOutputEvent: W3WAppEventConvertable {
   /// the live capture switch was switched
   case liveCaptureSwitch(Bool)
   
-  /// a footer button was tapped
-  case footerButton(W3WSuggestionsViewAction, suggestions: [W3WSuggestion])
+  /// footer button save tapped
+  case saveSuggestions(title: String, suggestions: [W3WSuggestion])
+  
+  /// footer button share tapped
+  case shareSuggestion(title: String, suggestion: W3WSuggestion)
+  
+  /// footer button view tapped
+  case viewSuggestions(title: String, suggestions: [W3WSuggestion])
   
   /// the close button was tapped
   case dismiss
   
   /// pass though any analytic events
   case analytic(W3WAppEvent)
+}
 
-  
+extension W3WOcrOutputEvent: W3WAppEventConvertable {
   public func asAppEvent() -> W3WAppEvent {
     switch self {
-
-      case .error(let error):
-        return W3WAppEvent(type: Self.self, name: "ocr.error", parameters: ["error": .error(error)])
-
-      case .detected(let suggestion):
-        return W3WAppEvent(type: Self.self, name: "ocr.detected", parameters: ["suggestion": .suggestion(suggestion)])
-
-      case .selected(let suggestion):
-        return W3WAppEvent(type: Self.self, name: "ocr.selected", parameters: ["suggestion": .suggestion(suggestion)])
-
-      case .importImage:
-        return W3WAppEvent(type: Self.self, name: "ocr.importImage")
-
-      case .captureButton:
-        return W3WAppEvent(type: Self.self, name: "ocr.captureButton")
-
-      case .liveCaptureSwitch(let value):
-        return W3WAppEvent(type: Self.self, name: "ocr.liveCaptureSwitch", parameters: ["value": .boolean(value)])
-
-      case .footerButton(let action, suggestions: let suggestions):
-        return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(action.title)])
-
-      case .dismiss:
-        return W3WAppEvent(type: Self.self, name: "ocr.dismiss")
-        
-      case .analytic(let event):
-        return event
+      
+    case .error(let error):
+      return W3WAppEvent(type: Self.self, name: "ocr.error", parameters: ["error": .error(error)])
+      
+    case .detected(let suggestion):
+      return W3WAppEvent(type: Self.self, name: "ocr.detected", parameters: ["suggestion": .suggestion(suggestion)])
+      
+    case .selected(let suggestion):
+      return W3WAppEvent(type: Self.self, name: "ocr.selected", parameters: ["suggestion": .suggestion(suggestion)])
+      
+    case .importImage:
+      return W3WAppEvent(type: Self.self, name: "ocr.importImage")
+      
+    case .captureButton:
+      return W3WAppEvent(type: Self.self, name: "ocr.captureButton")
+      
+    case .liveCaptureSwitch(let value):
+      return W3WAppEvent(type: Self.self, name: "ocr.liveCaptureSwitch", parameters: ["value": .boolean(value)])
+      
+    case .saveSuggestions(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
+      
+    case .shareSuggestion(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
+      
+    case .viewSuggestions(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
+      
+    case .dismiss:
+      return W3WAppEvent(type: Self.self, name: "ocr.dismiss")
+      
+    case .analytic(let event):
+      return event
     }
   }
-  
-
 }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
@@ -38,9 +38,6 @@ public protocol W3WOcrViewModelProtocol: ObservableObject {
   /// the ocr service crop rect
   var ocrCropRect: W3WEvent<CGRect> { get }
   
-  /// the suggestions that ocr collects
-  var suggestions: W3WSelectableSuggestions { get }
-  
   /// view model for the panel in the bottom sheet
   var panelViewModel: W3WPanelViewModel { get set }
   

--- a/Sources/W3WSwiftComponentsOcr/Presenters/OcrStill/Events/W3WOcrStillOutputEvent.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/OcrStill/Events/W3WOcrStillOutputEvent.swift
@@ -11,13 +11,10 @@ import W3WSwiftCore
 import W3WSwiftAppEvents
 
 
-public enum W3WOcrStillOutputEvent: W3WAppEventConvertable {
+public enum W3WOcrStillOutputEvent {
   
   /// an error happened
   case error(W3WError)
-  
-  /// footer button tapped
-  case footerButton(W3WSuggestionsViewAction, suggestions: [W3WSuggestion])
   
   /// when the user selects an address
   case selected(W3WSuggestion)
@@ -25,27 +22,43 @@ public enum W3WOcrStillOutputEvent: W3WAppEventConvertable {
   /// try again button tapped
   case tryAgain
   
+  /// footer button save tapped
+  case saveSuggestions(title: String, suggestions: [W3WSuggestion])
+  
+  /// footer button share tapped
+  case shareSuggestion(title: String, suggestion: W3WSuggestion)
+  
+  /// footer button view tapped
+  case viewSuggestions(title: String, suggestions: [W3WSuggestion])
+  
   /// dismiss teh view
   case dismiss
   
   /// pass though any analytic events
   case analytic(W3WAppEvent)
-  
-  
+}
+
+extension W3WOcrStillOutputEvent: W3WAppEventConvertable {
   public func asAppEvent() -> W3WAppEvent {
     switch self {
       
     case .error(let error):
       return W3WAppEvent(type: Self.self, name: "ocr.error", parameters: ["error": .error(error)])
       
-    case .footerButton(let action, suggestions: let suggestions):
-      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(action.title)])
-      
     case .selected(let suggestion):
       return W3WAppEvent(type: Self.self, name: "ocr.selected", parameters: ["suggestion": .suggestion(suggestion)])
       
     case .tryAgain:
       return W3WAppEvent(type: Self.self, name: "ocr.tryAgain")
+      
+    case .saveSuggestions(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
+      
+    case .shareSuggestion(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
+      
+    case .viewSuggestions(let title, _):
+      return W3WAppEvent(type: Self.self, name: "ocr.footerButton", parameters: ["action": .text(title)])
       
     case .dismiss:
       return W3WAppEvent(type: Self.self, name: "ocr.dismiss")
@@ -54,5 +67,4 @@ public enum W3WOcrStillOutputEvent: W3WAppEventConvertable {
       return event
     }
   }
-  
 }


### PR DESCRIPTION
## Summary

This PR reworks the **bottom sheet logic** to address multiple issues and improve maintainability.

### Issues Resolved
- **Memory leak**: The panel item count kept increasing every time the user performed an action.
- **Animation bug**: Incorrect height animation when new scan results appear.
- **Complexity**: Logic was scattered across multiple classes and modules.
- **Testing**: Lack of unit test coverage for bottom sheet logic.

---

## Implementation Details

Previously, the implementation involved:
- `BottomSheetLogic` classes.
- `W3WSelectableSuggestions`, `W3WSelectableSuggestion`.
- Logic spread across:
  - **w3w-iOS-app** → save, share, view actions.
  - **w3w-swift-components-ocr** → toggling header visibility.

In the new implementation:
- The entire logic is consolidated into ~150 lines inside `W3WPanelViewModel`.
- Leverages **SwiftUI’s reactive nature** & `Combine`’s `ObservableObject`.
  - Example: Footer section is recalculated automatically when its dependencies change — no need for manual calls like `recalculateFooter()`.
- This change may reduce `W3WPanelViewModel`’s reusability, but greatly improves **readability** and **testability**.

---

## Changes by Module

### **w3w-swift-presenter**
- **Removed unused classes:**
  - `W3WPanelItemList`
  - `W3WPanelActionItemView`
  - `W3WPanelMessageView`
  - `W3WPanelTappableRow`
- **Deprecated** (still referenced by old `BottomSheetLogic` classes):
  - `W3WSelectableSuggestions`
  - `W3WSelectableSuggestion`
- **Added**: 12+ unit tests based on [OCR Scan Result display logic](https://www.notion.so/what3words/OCR-Scan-Result-display-logic-1fb4eb2734f780b3b138c8f10b419fb0)

---

### **w3w-swift-components-ocr**
- Removed `BottomSheetLogic` class references (now works only with `PanelViewModel` output).

---

### **w3w-iOS-app**
- Migrated **save**, **share**, **view** actions to `w3w-swift-presenter`.

---

## Testing
- Added comprehensive unit test coverage for the new bottom sheet logic.
- Verified memory usage no longer grows after repeated actions.
- Confirmed smooth animation of height changes when scan results update.
