### PR TITLE
Task/mt 8089 wrong ratio captured image

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Lib/Camera/W3WOcrCamera.swift
+++ b/Sources/W3WSwiftComponentsOcr/Lib/Camera/W3WOcrCamera.swift
@@ -18,6 +18,7 @@ import W3WOcrSdk
 /// Interface for iOS' camera for the OCR SDK
 @available(macCatalyst 14.0, *)
 public class W3WOcrCamera: W3WVideoStream {
+  let id = UUID()
   
   // MARK: Vars
   

--- a/Sources/W3WSwiftComponentsOcr/Lib/Camera/W3WPhotoCaptureDelegate.swift
+++ b/Sources/W3WSwiftComponentsOcr/Lib/Camera/W3WPhotoCaptureDelegate.swift
@@ -11,78 +11,65 @@ import AVKit
 // This class will act as the delegate for AVCapturePhotoOutput
 // It needs to be an NSObject to conform to AVCapturePhotoCaptureDelegate
 class PhotoCaptureProcessor: NSObject, AVCapturePhotoCaptureDelegate {
-    private var completionHandler: ((CGImage?) -> Void)
+  var crop: CGRect?
+  
+  var completionHandler: ((CGImage?) -> Void)?
     
-    init(completion: @escaping (CGImage?) -> Void) {
-        self.completionHandler = completion
+  func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+    if let error = error {
+      print("Error capturing photo: \(error.localizedDescription)")
+      completionHandler?(nil)
+      return
+    }
+
+    guard let cgImage = photo.cgImageRepresentation() else {
+      completionHandler?(nil)
+      return
     }
     
-    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        if let error = error {
-            print("Error capturing photo: \(error.localizedDescription)")
-            completionHandler(nil)
-            return
-        }
-            
-        // Fix orientation before converting to CGImage, since orientation metadata is lost in CGImage.
-        guard let imageData = photo.fileDataRepresentation(),
-              let uiImage = UIImage(data: imageData)?.orientationFixed,
-              let cgImage = uiImage.cgImage else {
-            print("Could not create UIImage from data.")
-            completionHandler(nil)
-            return
-        }
-        
-        completionHandler(cgImage)
+    guard let crop else {
+      completionHandler?(cgImage.oriented(photo.metadata))
+      return
     }
+    
+    let cropRect = CGRect(
+      x: crop.origin.x * CGFloat(cgImage.width),
+      y: crop.origin.y * CGFloat(cgImage.height),
+      width: crop.width * CGFloat(cgImage.width),
+      height: crop.height * CGFloat(cgImage.height)
+    )
+    guard let croppedImage = cgImage.cropping(to: cropRect) else {
+      completionHandler?(cgImage.oriented(photo.metadata))
+      return
+    }
+    
+    completionHandler?(croppedImage.oriented(photo.metadata))
+  }
 }
 
-private extension UIImage {
-    var orientationFixed: UIImage {
-        guard imageOrientation != .up, let cgImage, let colorSpace = cgImage.colorSpace else { return self }
-        
-        var transform = CGAffineTransform.identity
-        switch imageOrientation {
-        case .down, .downMirrored:
-            transform = transform.translatedBy(x: size.width, y: size.height)
-            transform = transform.rotated(by: CGFloat(Double.pi))
-            
-        case .left, .leftMirrored:
-            transform = transform.translatedBy(x: size.width, y: 0)
-            transform = transform.rotated(by: CGFloat(Double.pi/2))
-            
-        case .right, .rightMirrored:
-            transform = transform.translatedBy(x: 0, y: size.height)
-            transform = transform.rotated(by: CGFloat(-Double.pi/2))
-            
-        case .up, .upMirrored:
-            break
-            
-        @unknown default:
-            break
-        }
-                
-        if let ctx = CGContext(
-            data: nil,
-            width: Int(size.width),
-            height: Int(size.height),
-            bitsPerComponent: cgImage.bitsPerComponent,
-            bytesPerRow: 0,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) {
-            ctx.concatenate(transform)
-            
-            switch imageOrientation {
-            case .left, .leftMirrored, .right, .rightMirrored:
-                ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: size.height, height: size.width))
-                
-            default:
-                ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
-            }
-            if let finalImage = ctx.makeImage() {
-                return (UIImage(cgImage: finalImage))
-            }
-        }
-        return self
-    }
+private extension CGImage {
+  /**
+   Returns a new `CGImage` with the correct orientation applied
+   based on the provided EXIF metadata.
+   
+   - Important:
+   `AVCapturePhoto.cgImageRepresentation()` always returns the raw image
+   from the sensor in its default orientation (usually landscape),
+   and **does not** apply the orientation automatically.
+   The actual orientation is stored in `photo.metadata[kCGImagePropertyOrientation]`.
+   
+   - Parameter metadata: A metadata dictionary from `AVCapturePhoto.metadata`
+   containing the `kCGImagePropertyOrientation` key.
+   
+   - Returns: A new `CGImage` with the correct orientation applied,
+   or `nil` if the transformation fails.
+   */
+  func oriented(_ metadata: [String : Any]) -> CGImage? {
+    let orientationRaw = metadata[kCGImagePropertyOrientation as String] as? UInt32 ?? 1
+    let exifOrientation = CGImagePropertyOrientation(rawValue: orientationRaw) ?? .up
+    
+    let ciImage = CIImage(cgImage: self).oriented(exifOrientation)
+    let context = CIContext(options: nil)
+    return context.createCGImage(ciImage, from: ciImage.extent)
+  }
 }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModel.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModel.swift
@@ -48,17 +48,17 @@ public class W3WOcrViewModel: W3WOcrViewModelProtocol, W3WEventSubscriberProtoco
   /// the ocr service
   public var ocr: W3WOcrProtocol?
   
-  /// the ocr service crop rect
-  public let ocrCropRect = W3WEvent<CGRect>()
-  
   /// the camera
   @Published public var camera: W3WOcrCamera?
 
   /// view model for the panel in the bottom sheet
   public var panelViewModel: W3WPanelViewModel
   
+  /// indicates if there is a camera session running
+  @Published public private(set) var isPreviewing = false
+  
   /// indicates if there is a photo being processed
-  @Published public var isTakingPhoto = false
+  @Published public private(set) var isTakingPhoto = false
 
   /// translations for text
   public var translations: W3WTranslationsProtocol
@@ -72,10 +72,6 @@ public class W3WOcrViewModel: W3WOcrViewModelProtocol, W3WEventSubscriberProtoco
   /// indicates it the live scan feature is locked or not
   var liveScanLocked = W3WLive<Bool>(true)
 
-  /// allows the suggestions to be selected into a list
-  var selectableSuggestionList = W3WLive<Bool>(true)
-  
-  
   /// model for the ocr view
   public init(ocr: W3WOcrProtocol,
               theme: W3WLive<W3WTheme?>? = nil,
@@ -198,6 +194,7 @@ private extension W3WOcrViewModel {
   
     firstLiveScanResultHappened = false
     camera.start()
+    isPreviewing = true
     
     subscribe(to: $viewType) { [weak self] value in
       switch value {
@@ -220,6 +217,7 @@ private extension W3WOcrViewModel {
     camera?.stop()
     camera = nil
     ocr?.stop {}
+    isPreviewing = false
   }
 }
 

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModel.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModel.swift
@@ -52,7 +52,7 @@ public class W3WOcrViewModel: W3WOcrViewModelProtocol, W3WEventSubscriberProtoco
   public let ocrCropRect = W3WEvent<CGRect>()
   
   /// the camera
-  public let camera = W3WLive<W3WOcrCamera?>(nil)
+  @Published public var camera: W3WOcrCamera?
 
   /// view model for the panel in the bottom sheet
   public var panelViewModel: W3WPanelViewModel
@@ -194,7 +194,7 @@ private extension W3WOcrViewModel {
   /// start scanning
   func start() {
     guard let camera = W3WOcrCamera.get(camera: .back) else { return }
-    defer { self.camera.send(camera) }
+    defer { self.camera = camera }
   
     firstLiveScanResultHappened = false
     camera.start()
@@ -217,8 +217,8 @@ private extension W3WOcrViewModel {
   
   /// Stop the scanning
   func stop() {
-    camera.value?.stop()
-    camera.send(nil)
+    camera?.stop()
+    camera = nil
     ocr?.stop {}
   }
 }
@@ -258,7 +258,7 @@ private extension W3WOcrViewModel {
   }
     
   func capturePhoto() {
-    guard let camera = camera.value else { return }
+    guard let camera else { return }
     
     isTakingPhoto = true
     camera.captureStillImage { [weak self] image in

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
@@ -33,7 +33,7 @@ public protocol W3WOcrViewModelProtocol: ObservableObject {
   var ocr: W3WOcrProtocol? { get set }
   
   /// the camera
-  var camera: W3WLive<W3WOcrCamera?> { get }
+  var camera: W3WOcrCamera? { get }
   
   /// the ocr service crop rect
   var ocrCropRect: W3WEvent<CGRect> { get }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/ViewModel/W3WOcrViewModelProtocol.swift
@@ -35,11 +35,11 @@ public protocol W3WOcrViewModelProtocol: ObservableObject {
   /// the camera
   var camera: W3WOcrCamera? { get }
   
-  /// the ocr service crop rect
-  var ocrCropRect: W3WEvent<CGRect> { get }
-  
   /// view model for the panel in the bottom sheet
   var panelViewModel: W3WPanelViewModel { get set }
+  
+  /// indicates if there is a camera session running
+  var isPreviewing: Bool { get }
   
   /// indicates if there is a photo being processed
   var isTakingPhoto: Bool { get }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WOcrViewController.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WOcrViewController.swift
@@ -19,20 +19,13 @@ import W3WOcrSdk
 
 /// the UIKit view controller holding the OCR view
 @available(macCatalyst 14.0, *)
-open class W3WOcrViewController<ViewModel: W3WOcrViewModelProtocol>: W3WHostingViewController<W3WOcrScreen<ViewModel>>, W3WEventSubscriberProtocol {
-  public var subscriptions = W3WEventsSubscriptions()
-  
-  /// the UIKit OCR view
-  var ocrView: W3WOcrView
-
-  /// user defined camera crop, if nil then defaults are used, if set then the camera crop is set to this (specified in view coordinates)
-  var customCrop: CGRect?
+open class W3WOcrViewController<ViewModel: W3WOcrViewModelProtocol>: W3WHostingViewController<W3WOcrScreen<ViewModel>> {
 
   /// keeps a reference to objects to keep them alive and release them on destruction
   public var keepAlive: [Any?]
 
   /// the view model for the OCR view
-  var viewModel: ViewModel
+  private let viewModel: ViewModel
   
 
   /// view controller containing a Settings view
@@ -42,39 +35,12 @@ open class W3WOcrViewController<ViewModel: W3WOcrViewModelProtocol>: W3WHostingV
   public init(viewModel: ViewModel, keepAlive: [Any?] = []) {
     self.keepAlive = keepAlive
     self.viewModel = viewModel
-
-    // make the UIKit OCR view
-    ocrView = W3WOcrView(frame: .w3wWhatever)
-    
-    // set the colours
-    ocrView.set(lineColor: W3WCoreColor.white.uiColor, lineGap: 1.0)
     
     // make the SwitUI representable view for the UIKit view
-    let ocrScreen = W3WOcrScreen(viewModel: viewModel, ocrView: ocrView)
+    let ocrScreen = W3WOcrScreen(viewModel: viewModel)
 
     // start 'er up
     super.init(rootView: ocrScreen)
-   
-    // set colours and bind to themes
-    view.backgroundColor = W3WColor.darkBlue.current.uiColor
-    ocrView.set(scheme: viewModel.theme.value?.ocrScheme(for: .idle))
-    ocrView.set(lineColor: W3WCoreColor.white.uiColor, lineGap: 1.0)
-    subscribe(to: viewModel.theme)  { [weak self] theme in
-      W3WThread.queueOnMain {
-        self?.ocrView.set(scheme: viewModel.theme.value?.ocrScheme(for: .idle))
-      }
-    }
-    // attach the camera to the OCR view
-    subscribe(to: viewModel.camera)  { [weak self] camera in
-      guard let camera else { return }
-      self?.ocrView.set(camera: camera)
-    }
-    subscribe(to: viewModel.ocrCropRect)  { [weak self] rect in
-      self?.customCrop = rect
-      W3WThread.queueOnMain {
-        self?.updateCrop()
-      }
-    }
   }
 
   
@@ -87,69 +53,5 @@ open class W3WOcrViewController<ViewModel: W3WOcrViewModelProtocol>: W3WHostingV
     super.viewDidAppear(animated)
     viewModel.input.send(.startScanning)
   }
-  
-  
-  /// user defined camera crop, if nil then defaults are used, if set then the camera crop is set to this (specified in view coordinates)
-  /// - Parameters:
-  ///     - crop: camera crop to use specified in view coordinates
-  public func set(crop: CGRect?) {
-    self.customCrop = crop
-  }
-
-  
-  /// set the OCR crop to a value that makes sense for the current view
-  func updateCrop() {
-    if let customCrop = customCrop {
-      ocrView.set(crop: customCrop)
-    } else {
-      ocrView.set(crop: defaultCrop())
-    }
-  }
-
-  
-  /// calculate a good crop for the OCR viewfinder
-  func defaultCrop() -> CGRect {
-    let inset = W3WSettings.ocrCropInset
-    let width: CGFloat
-    let height: CGFloat
-    
-    // iPad width and height
-    if UIDevice.current.userInterfaceIdiom == .pad {
-      width = ocrView.bounds.width - inset * 2.0
-      height = width * 0.75
-      
-    // potrait width and height
-    } else  if ocrView.bounds.width < ocrView.bounds.height {
-      width = ocrView.bounds.width - inset * 2.0
-      height = width
-      
-    // landscape width and height
-    } else {
-      width = ocrView.bounds.width * 0.8 - inset * 2.0
-      height = width * W3WSettings.ocrViewfinderRatioLandscape
-    }
-    
-    // the crop
-    let crop = CGRect(
-      origin: CGPoint(
-        x: (ocrView.bounds.width - width) / 2,
-        y: W3WSettings.ocrCropInset * 2.0 + view.safeAreaInsets.top),
-      size: CGSize(
-        width: width,
-        height: height
-      )
-    )
-    
-    return crop
-  }
-
-  
-  /// when the window dimensions change, update the OCR viewfinder crop
-  open override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    updateCrop()
-  }
-  
-  
 }
 

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
@@ -56,10 +56,23 @@ private extension W3WSuOcrView {
         })
         .store(in: &cancellables)
     }
-    
+        
     override func layoutSubviews() {
       super.layoutSubviews()
       previewLayer.frame = bounds
+      previewLayer.connection?.videoOrientation = UIDevice.current.videoOrientation
+    }
+  }
+}
+
+private extension UIDevice {
+  var videoOrientation: AVCaptureVideoOrientation {
+    switch orientation {
+    case .portrait: .portrait
+    case .portraitUpsideDown: .portraitUpsideDown
+    case .landscapeLeft: .landscapeRight
+    case .landscapeRight: .landscapeLeft
+    default: .portrait
     }
   }
 }

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
@@ -7,13 +7,15 @@
 
 import SwiftUI
 import AVFoundation
-
+import Combine
 
 struct W3WSuOcrView: UIViewRepresentable {
   let session: AVCaptureSession?
+  let cropRect: CGRect
+  let previewCropHandler: (CGRect) -> Void
   
   func makeUIView(context: Context) -> UIView {
-    PreviewView(session: session)
+    PreviewView(session: session, cropRect: cropRect, previewCropHandler: previewCropHandler)
   }
   
   func updateUIView(_ uiView: UIView, context: Context) {}
@@ -23,13 +25,36 @@ struct W3WSuOcrView: UIViewRepresentable {
 private extension W3WSuOcrView {
   final class PreviewView: UIView {
     private let previewLayer = AVCaptureVideoPreviewLayer()
+    private var cancellables: Set<AnyCancellable> = []
     
-    convenience init(session: AVCaptureSession?) {
+    convenience init(
+      session: AVCaptureSession?,
+      cropRect: CGRect,
+      previewCropHandler: @escaping (CGRect) -> Void
+    ) {
       self.init(frame: .zero)
       previewLayer.videoGravity = .resizeAspectFill
       layer.addSublayer(previewLayer)
-      
       previewLayer.session = session
+      
+      // Observe when the preview layer is actually rendering (`isPreviewing == true`)
+      // and when it has a valid layout (`bounds != .zero`).
+      // Once both conditions are met, wait 1 second to ensure the capture session
+      // has rendered at least one frame on the preview layer, then convert the
+      // given cropRect from layer coordinates into a normalized metadata rect
+      // (0–1 in the capture coordinate space) and forward it through
+      // `previewCropHandler`. This ensures the crop area is calculated only after
+      // the preview is ready and displaying frames correctly.
+      let isPreviewing = previewLayer.publisher(for: \.isPreviewing).filter { $0 }
+      let didLayout = previewLayer.publisher(for: \.bounds).filter { $0 != .zero }
+      Publishers.CombineLatest(isPreviewing, didLayout)
+        .delay(for: .seconds(1), scheduler: RunLoop.main)
+        .sink(receiveValue: { [weak self] frame in
+          guard let self else { return }
+          let normalized = previewLayer.metadataOutputRectConverted(fromLayerRect: cropRect)
+          previewCropHandler(normalized)
+        })
+        .store(in: &cancellables)
     }
     
     override func layoutSubviews() {

--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WSuOcrView.swift
@@ -5,31 +5,36 @@
 //  Created by Dave Duprey on 30/04/2025.
 //
 
-import UIKit
 import SwiftUI
-import W3WSwiftThemes
+import AVFoundation
 
 
-/// Holds a UIKit W3WOcrView in a SwiftUI view
 struct W3WSuOcrView: UIViewRepresentable {
+  let session: AVCaptureSession?
   
-  let ocrView: W3WOcrView
+  func makeUIView(context: Context) -> UIView {
+    PreviewView(session: session)
+  }
   
+  func updateUIView(_ uiView: UIView, context: Context) {}
+}
 
-  /// Holds a UIKit W3WOcrView in a SwiftUI view
-  /// - Parameters:
-  ///     - ocrView: the UIView derived W3WOcrView to embed
-  public init(ocrView: W3WOcrView) {
-    self.ocrView = ocrView
+
+private extension W3WSuOcrView {
+  final class PreviewView: UIView {
+    private let previewLayer = AVCaptureVideoPreviewLayer()
+    
+    convenience init(session: AVCaptureSession?) {
+      self.init(frame: .zero)
+      previewLayer.videoGravity = .resizeAspectFill
+      layer.addSublayer(previewLayer)
+      
+      previewLayer.session = session
+    }
+    
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      previewLayer.frame = bounds
+    }
   }
-  
-  
-  func makeUIView(context: Context) -> W3WOcrView {
-    return ocrView
-  }
-  
-  
-  func updateUIView(_ uiView: W3WOcrView, context: Context) {
-  }
-  
 }


### PR DESCRIPTION
## Changes

- Replace `W3WOcrView` with a SwiftUI-based approach  
  → See `W3WSuOcrView` & `W3WOcrScreen` for details
- Rework OCR focus area calculation  
  - Previously: used `W3WOcrCoordinateMaths`  
  - Now: use builtin `AVCaptureVideoPreviewLayer.metadataOutputRectConverted(fromLayerRect:)`
- Fix wrong crop ratio when taking a photo
- Fix incorrect crop rect on first appearance  
  - Removed previous workaround:  

    ```swift
    .onAppear {
        /// When `W3WOcrScreen` reappears, the OCR crop region can become incorrect.
        /// This timer re-applies the crop rect as a temporary workaround.
        /// TODO: Refactor once `W3WOcrView` has been updated for SwiftUI.
        Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
          viewModel.ocrCropRect.send(ocrCropRect)
        }
    }
    ```
- Fix a potential crash when dismissing OCR immediately after it appears
  - Removed unnecessary cleanup
  - Schedule task synchronously on the thread instead of asynchronously