### PR TITLE
[MT-9044] Update minimum iOS version to 16.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "w3w-swift-components-ocr",
     defaultLocalization: "en",
     platforms: [
-      .macOS(.v10_13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+      .macOS(.v10_13), .iOS("16.1"), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
## Update minimum iOS version to 16.1

Bump platform deployment target to iOS 16.1 (consumes 16.1 w3w-* products).

Part of [MT-9044](https://linear.app/what3words/issue/MT-9044/ios-update-minimum-ios-app-version-to-161).