### PR TITLE
[MT-8922] Tag containers with w3wTestTagContainer

### DIFF
--- a/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WOcrScreen.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/Ocr/Views/W3WOcrScreen.swift
@@ -98,7 +98,7 @@ public struct W3WOcrScreen<ViewModel: W3WOcrViewModelProtocol>: View {
         }) {
           W3WPanelScreen(viewModel: viewModel.panelViewModel)
             .animation(nil, value: hasSuggestions)
-            .w3wTestTag(W3WTestTags.Ocr.resultsList)
+            .w3wTestTagContainer(W3WTestTags.Ocr.resultsList)
         }
         .animation(.easeIn, value: hasSuggestions)
         .onReceive(viewModel.panelViewModel.hasSuggestions, perform: updateHasSuggestions)

--- a/Sources/W3WSwiftComponentsOcr/Presenters/OcrStill/Views/W3WOcrStillScreen.swift
+++ b/Sources/W3WSwiftComponentsOcr/Presenters/OcrStill/Views/W3WOcrStillScreen.swift
@@ -72,7 +72,7 @@ public struct W3WOcrStillScreen<ViewModel: W3WOcrStillViewModelProtocol>: View {
               W3WProgressView(color: W3WColor.w3wLabelsPrimaryBlackInverse.uiColor)
             } else {
               W3WPanelScreen(viewModel: viewModel.panelViewModel)
-                .w3wTestTag(W3WTestTags.Ocr.resultsList)
+                .w3wTestTagContainer(W3WTestTags.Ocr.resultsList)
             }
           }
       }


### PR DESCRIPTION
## Problem

SwiftUI applies an accessibility identifier to every descendant of the view it is attached to, and the outermost one wins. MT-8922 tags placed on containers were therefore hiding the tags of the views inside them — on a Beta build the whole search bar answered to `map.searchBar.root`, so `map.searchBar.input`, `.menuButton` and `.proLogo` never reached the accessibility tree.

## Changes

Container-level tags now use `w3wTestTagContainer(_:)` instead of `w3wTestTag(_:)`. The new modifier marks the view as an accessibility container before setting the identifier, so child tags survive and the container is still addressable by its own tag. Leaf tags (buttons, labels, fields) are untouched.

## Depends on

`w3w-swift-app-accessibility-identifiers` PR adding `w3wTestTagContainer`. This needs that release, and the identifiers lower bound raised to it, before the version bump here.

## Verification

Beta Debug on iPhone 17 simulator with the local packages wired in: build green, and an accessibility-tree dump over map / drawer / settings / share-settings shows zero repeated tag ids, with the previously-masked ids present.
